### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ That should give you a file called ``my_map.pdf`` in your current working direct
 This is by far the biggest hassle. Once it is done, however, it never needs to
 be done again. These instructions work on Ubuntu 12.04. You’ll probably need to
 modify them to suit your particular environment. These directions also assume
-you have [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/)
+you have [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)
 setup as well.
 
 ```bash


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.